### PR TITLE
Add loading spinner to the bias analysis page

### DIFF
--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -456,6 +456,10 @@ function drawBiasAnalysis() {
 
     const overallAverages = computeOverallAverages(data);
     container.innerHTML = ""; // Clear previous content
+    const loadingSpinner = document.getElementById("loading-spinner");
+    if (loadingSpinner !== null) {
+        loadingSpinner.style.display = "none";
+    }
 
     // Sort firms by poll count in descending order
     const sortedFirms = sortPollingFirms(data);

--- a/src/bias/index.html
+++ b/src/bias/index.html
@@ -9,6 +9,13 @@ processApi: true
 {% include top.html %}
 
 <div id="bias" class="container-xxl bd-gutter mt-3 my-md-4 bd-layout">
+    <div id="loading-spinner">
+        <div class="d-flex justify-content-center" style="min-height: 300px">
+            <div class="spinner-border align-self-center" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+    </div>
     <div class="container-fluid">
         <div class="row" id="biasAnalysisContainer"></div>
     </div>


### PR DESCRIPTION
- It goes through a lot of data, and it visually lags behind on bad connections